### PR TITLE
Fix for regression test failure

### DIFF
--- a/tests/prediction/singleorder/automaton_rule30_prediction_test.py
+++ b/tests/prediction/singleorder/automaton_rule30_prediction_test.py
@@ -45,12 +45,14 @@ class Rule30AutomataPredictionTest(unittest.TestCase):
       else: 
         prediction_history.append(0.0)
       
-      correctness = reduce(lambda x, y: x + y, prediction_history) / len(prediction_history)
-      
+      correctness = reduce(lambda x, y: x + y,
+                           prediction_history) / len(prediction_history)
+
       if count == iterations:
         unittest.TestCase.assertEqual(
           self, 1.0, correctness, 
-          "Predictions should be 100 percent correct after reaching %i iterations." % iterations
+          "Predictions should be 100 percent correct after reaching %i "
+          "iterations." % iterations
         )
 
       result = model.run(input_row)

--- a/tests/prediction/singleorder/rule_30_model_params.py
+++ b/tests/prediction/singleorder/rule_30_model_params.py
@@ -83,7 +83,7 @@ MODEL_PARAMS = \
                                  'maxAge': 0,
                                  'maxSegmentsPerCell': 128,
                                  'maxSynapsesPerSegment': 32,
-                                 'minThreshold': 9,
+                                 'minThreshold': 12,
                                  'newSynapseCount': 20,
                                  'outputType': 'normal',
                                  'pamLength': 1,


### PR DESCRIPTION
The underlying failure was due to a spatial pooler change. The result of that is similar to changing the random seed so it's basically random variation. Here I updated minThreshold to be more in line with other models and make this model a bit more robust. This brings it back in line with previous performance.

Fix line wrap issue.

Fixes #35