### PR TITLE
NUP-2256 Update NAB regression test benchmark values

### DIFF
--- a/tests/anomaly/nab/benchmark_results.json
+++ b/tests/anomaly/nab/benchmark_results.json
@@ -1,7 +1,7 @@
 {
     "numenta": {
-        "reward_low_FN_rate": 69.58,
-        "reward_low_FP_rate": 57.49,
-        "standard": 65.14
+        "reward_low_FN_rate": 68.71,
+        "reward_low_FP_rate": 56.58,
+        "standard": 64.27
     }
 }


### PR DESCRIPTION
Fixes JIRA [NUP-2256](https://jira.numenta.com/browse/NUP-2256).

Note that the travis CI build for this PR will fail due to a permissions issue that was originally brought to my attention by @rhyolight. This is expected for all PRs against nupic.regression. What we need to verify is that the next nightly build passes.

@subutai @BoltzmannBrain 