### PR TITLE
Replaced deprecated use of clVerbosity as parameter name.

### DIFF
--- a/tests/anomaly/one_gym/rec_center_hourly_model_params.py
+++ b/tests/anomaly/one_gym/rec_center_hourly_model_params.py
@@ -14,7 +14,7 @@ MODEL_PARAMS = \
                                       u'autoDetectThreshold': None,
                                       u'autoDetectWaitRecords': None},
                    'clParams': { 'alpha': 0.01962508905154251,
-                                 'clVerbosity': 0,
+                                 'verbosity': 0,
                                  'regionName': 'CLAClassifierRegion',
                                  'steps': '1'},
                    'inferenceType': 'TemporalAnomaly',

--- a/tests/prediction/singleorder/rule_30_model_params.py
+++ b/tests/prediction/singleorder/rule_30_model_params.py
@@ -14,7 +14,7 @@ MODEL_PARAMS = \
                                       u'autoDetectThreshold': None,
                                       u'autoDetectWaitRecords': None},
                    'clParams': { 'alpha': 0.014085570221302232,
-                                 'clVerbosity': 0,
+                                 'verbosity': 0,
                                  'regionName': 'CLAClassifierRegion',
                                  'steps': '1'},
                    'inferenceType': 'TemporalMultiStep',


### PR DESCRIPTION
Fixes #43. @rhyolight 