### PR TITLE
Bad json formatting in #47

### DIFF
--- a/tests/anomaly/nab/benchmark_results.json
+++ b/tests/anomaly/nab/benchmark_results.json
@@ -8,4 +8,5 @@
         "reward_low_FN_rate": 65.321257648405165,
         "reward_low_FP_rate": 51.940355197849136,
         "standard": 60.050851989827585
+    }
 }


### PR DESCRIPTION
Sorry @rhyolight, some bad json formatting in #47 caused [this run](https://travis-ci.org/numenta/nupic.regression) to fail 😒 