### PR TITLE
Increase classifier learning rate

### DIFF
--- a/tests/prediction/singleorder/rule_30_model_params.py
+++ b/tests/prediction/singleorder/rule_30_model_params.py
@@ -13,7 +13,7 @@ MODEL_PARAMS = \
   'modelParams': { 'anomalyParams': { u'anomalyCacheRecords': None,
                                       u'autoDetectThreshold': None,
                                       u'autoDetectWaitRecords': None},
-                   'clParams': { 'alpha': 0.014085570221302232,
+                   'clParams': { 'alpha': 0.05,
                                  'verbosity': 0,
                                  'regionName': 'SDRClassifierRegion',
                                  'steps': '1'},


### PR DESCRIPTION
@rhyolight I noticed that the classifier learning rate is not high enough to pass the regression test. This is probably due to some other changes of the SDR classifier region. The tests passed after I increased learning rate and with the fix https://github.com/numenta/nupic.core/pull/1348.